### PR TITLE
[Feature] 초기 도메인 설계, 패키지 분리

### DIFF
--- a/blaybus-backend/.gitignore
+++ b/blaybus-backend/.gitignore
@@ -35,3 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+application-dev.yml
+application-local.yml
+application-prod.yml
+application.yml

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/BaseEntity.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/BaseEntity.java
@@ -1,0 +1,22 @@
+package blaybus.blaybus_backend.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @Column(nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/ExperienceRecord.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/ExperienceRecord.java
@@ -1,0 +1,25 @@
+package blaybus.blaybus_backend.domain.experience;
+
+import blaybus.blaybus_backend.domain.member.Member;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+public class ExperienceRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member; // 경험치를 얻은 회원
+
+    @Column(nullable = false)
+    private int points; // 획득한 경험치
+
+    @Column(nullable = false)
+    private LocalDate date; // 획득 날짜
+
+    @Column(nullable = false)
+    private ExperienceType experienceType; // 경험치 종류
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/ExperienceRecord.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/ExperienceRecord.java
@@ -21,5 +21,6 @@ public class ExperienceRecord {
     private LocalDate date; // 획득 날짜
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private ExperienceType experienceType; // 경험치 종류
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/ExperienceType.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/ExperienceType.java
@@ -1,0 +1,14 @@
+package blaybus.blaybus_backend.domain.experience;
+
+public enum ExperienceType {
+    PERFORMANCE_REVIEW("인사 평가 경험치"),
+    LEADER_QUEST("리더 부여 퀘스트 경험치"),
+    JOB_QUEST("직무 부여 퀘스트 경험치"),
+    PROJECT("전사 프로젝트 경험치");
+
+    private final String description;
+
+    ExperienceType(String description) {
+        this.description = description;
+    }
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/Member.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/Member.java
@@ -1,0 +1,42 @@
+package blaybus.blaybus_backend.domain.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+import java.time.LocalDate;
+
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 기본 키 (자동 생성)
+
+    @Column(nullable = false, unique = true)
+    private String employeeNumber; // 사번
+
+    @Column(nullable = false)
+    private String name; // 이름
+
+    @Column(nullable = false)
+    private LocalDate hireDate; // 입사일
+
+    @Column(nullable = false)
+    private String department; // 소속
+
+    @Column(nullable = false)
+    private String jobGroup; // 직무그룹
+
+    @Column(nullable = false)
+    private MemberLevel memberLevel; // 레벨
+
+    @Column(nullable = false, unique = true)
+    private String username; // 아이디
+
+    @Column(nullable = false)
+    private String defaultPassword; // 기본 패스워드
+
+    private String updatedPassword; // 변경 패스워드
+
+    private int totalExperience; // 총 경험치
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/Member.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/Member.java
@@ -1,9 +1,6 @@
 package blaybus.blaybus_backend.domain.member;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 
 import java.time.LocalDate;
 
@@ -28,6 +25,7 @@ public class Member {
     private String jobGroup; // 직무그룹
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private MemberLevel memberLevel; // 레벨
 
     @Column(nullable = false, unique = true)
@@ -38,5 +36,6 @@ public class Member {
 
     private String updatedPassword; // 변경 패스워드
 
-    private int totalExperience; // 총 경험치
+    @Column(nullable = false, columnDefinition = "integer default 0")
+    private int totalExperience = 0; // 총 경험치
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/MemberLevel.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/MemberLevel.java
@@ -1,0 +1,34 @@
+package blaybus.blaybus_backend.domain.member;
+
+public enum MemberLevel {
+
+    F1_I(0, 13500),
+    F1_II(13501, 27000),
+    F2_I(27001, 39000),
+    F2_II(39001, 51000),
+    F2_III(51001, 63000),
+    F3_I(63001, 78000),
+    F3_II(78001, 93000),
+    F3_III(93001, 108000),
+    F4_I(108001, 126000),
+    F4_II(126001, 144000),
+    F4_III(144001, 162000),
+    F5(162001, Integer.MAX_VALUE);
+
+    private final int minExperience;
+    private final int maxExperience;
+
+    MemberLevel(int minExperience, int maxExperience) {
+        this.minExperience = minExperience;
+        this.maxExperience = maxExperience;
+    }
+
+    public static MemberLevel getLevelByExperience(int experience) {
+        for (MemberLevel level : values()) {
+            if (experience >= level.minExperience && experience <= level.maxExperience) {
+                return level;
+            }
+        }
+        throw new IllegalArgumentException("Experience value out of range: " + experience);
+    }
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/notification/Notification.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/notification/Notification.java
@@ -1,0 +1,19 @@
+package blaybus.blaybus_backend.domain.notification;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String type; // 알림 종류 (예: 경험치, 게시글)
+
+    @Column(nullable = false)
+    private String content; // 알림 내용
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/post/Post.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/post/Post.java
@@ -1,0 +1,7 @@
+package blaybus.blaybus_backend.domain.post;
+
+public class Post {
+    private Long id;
+    private String title;
+    private String content;
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/post/Post.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/post/Post.java
@@ -1,7 +1,19 @@
 package blaybus.blaybus_backend.domain.post;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
 public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 }

--- a/blaybus-backend/src/main/resources/application.properties
+++ b/blaybus-backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=blaybus-backend


### PR DESCRIPTION
## 📌 관련 이슈
close: #2 
<br>

## 💻 작업 내용
와이어프레임이 나와야 정확하게 정할 수 있겠지만 일단 틀이 필요할 거 같아서 최소한의 도메인 클래스를 만들어놨습니다. 
기능 개발하면서 리팩토링하는 방향으로 가면 될 것 같습니다.
<br>

## 🤔 어떤 부분에 집중하여 리뷰해야 할까요?
```
java/
└── blaybus/
    └── blaybus_backend/
        ├── domain/
        │   ├── admin/
        │   ├── experience/
        │   ├── member/
        │   ├── notification/
        │   └── post/
        ├── global/
        │   ├── common/
        │   ├── config/
        │   ├── exception/
        │   └── util/
        └── BlaybusBackendApplication.java
```
더 좋은, 보기 편한 패키지가 있는지 고민해주시면 감사하겠습니다!
그리고 경험치를 얻을 수 있는 방법이 네가지(인사 평가, 직무 퀘스트, 리더 퀘스트, 전사 프로젝트)인데 이걸 나누는게 좋을지 하나로 통일하는 게 좋을지 고민이 되네요...🤔  
<br>



# RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 회원 경험치 시스템 추가
	- 알림 기능 도입
	- 게시물 기능 구현

- **도메인 모델**
	- 회원(Member) 엔티티 생성
	- 회원 레벨(MemberLevel) 열거형 추가
	- 경험 기록(ExperienceRecord) 엔티티 추가
	- 경험 유형(ExperienceType) 열거형 생성

- **기타 변경사항**
	- 애플리케이션 설정 파일 무시 목록 업데이트
	- 애플리케이션 이름 속성 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->