### PR TITLE
feat: 프로필 캐릭터 수정, 캐릭터 정보 확인

### DIFF
--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/controller/MemberController.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/controller/MemberController.java
@@ -1,8 +1,6 @@
 package blaybus.blaybus_backend.domain.member.controller;
 
-import blaybus.blaybus_backend.domain.member.dto.InfoResponseDTO;
-import blaybus.blaybus_backend.domain.member.dto.UpdatePwRequestDTO;
-import blaybus.blaybus_backend.domain.member.dto.UpdatePwResponseDTO;
+import blaybus.blaybus_backend.domain.member.dto.*;
 import blaybus.blaybus_backend.domain.member.service.MemberService;
 import blaybus.blaybus_backend.global.common.SessionManager;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,6 +36,13 @@ public class MemberController {
         Long id = sessionManager.getMemberId(session);
         UpdatePwResponseDTO updateResponse = memberService.updatePw(id, updateRequest);
         return ResponseEntity.ok(updateResponse);
+    }
+
+    @PutMapping("/update-char")
+    public ResponseEntity<UpdatePCharResponseDTO> updatePChar(HttpSession session,
+            @RequestBody UpdatePCharRequestDTO req) {
+        Long id = sessionManager.getMemberId(session);
+        return ResponseEntity.ok(memberService.updatePChar(id, req));
     }
 
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/dto/InfoResponseDTO.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/dto/InfoResponseDTO.java
@@ -1,5 +1,6 @@
 package blaybus.blaybus_backend.domain.member.dto;
 
+import blaybus.blaybus_backend.domain.member.entity.ProfileCharacter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,4 +19,5 @@ public class InfoResponseDTO {
     private String loginId;
     private int totalExperience;
     private String levelName;
+    private ProfileCharacter profileCharacter;
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/dto/UpdatePCharRequestDTO.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/dto/UpdatePCharRequestDTO.java
@@ -1,0 +1,13 @@
+package blaybus.blaybus_backend.domain.member.dto;
+
+import blaybus.blaybus_backend.domain.member.entity.ProfileCharacter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdatePCharRequestDTO {
+    @Schema(description = "변경할 캐릭터", example = "남3", required = true)
+    private ProfileCharacter profileCharacter;
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/dto/UpdatePCharResponseDTO.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/dto/UpdatePCharResponseDTO.java
@@ -1,0 +1,8 @@
+package blaybus.blaybus_backend.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UpdatePCharResponseDTO {
+    private String message = "캐릭터가 성공적으로 변경되었습니다.";
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/entity/Member.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/entity/Member.java
@@ -43,6 +43,9 @@ public class Member {
     @Column(nullable = false, columnDefinition = "integer default 0")
     private int totalExperience = 0; // 총 경험치
 
+    @Column(nullable = false)
+    private ProfileCharacter profileCharacter; // 프로필 캐릭터
+
     @Column(length = 500)
     private String fcmToken;
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/entity/ProfileCharacter.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/entity/ProfileCharacter.java
@@ -1,0 +1,6 @@
+package blaybus.blaybus_backend.domain.member.entity;
+
+public enum ProfileCharacter {
+    // blaybus sample profile portrait
+    man1, man2, man3, man4, woman1, woman2, woman3, woman4
+}

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/entity/ProfileCharacter.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/entity/ProfileCharacter.java
@@ -2,5 +2,5 @@ package blaybus.blaybus_backend.domain.member.entity;
 
 public enum ProfileCharacter {
     // blaybus sample profile portrait
-    man1, man2, man3, man4, woman1, woman2, woman3, woman4
+    MAN1, MAN2, MAN3, MAN4, WOMAN1, WOMAN2, WOMAN3, WOMAN4
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/service/MemberService.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/service/MemberService.java
@@ -1,11 +1,8 @@
 package blaybus.blaybus_backend.domain.member.service;
 
-import blaybus.blaybus_backend.domain.member.dto.UpdatePwRequestDTO;
-import blaybus.blaybus_backend.domain.member.dto.UpdatePwResponseDTO;
+import blaybus.blaybus_backend.domain.member.dto.*;
 import blaybus.blaybus_backend.domain.member.repository.MemberRepository;
-import blaybus.blaybus_backend.domain.member.dto.InfoResponseDTO;
 import blaybus.blaybus_backend.domain.member.entity.Member;
-import blaybus.blaybus_backend.global.common.SessionManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -31,6 +28,7 @@ public class MemberService {
                 .loginId(member.getLoginId())
                 .totalExperience(member.getTotalExperience())
                 .levelName(memberRepository.findLevelNameById(id))
+                .profileCharacter(member.getProfileCharacter())
                 .build();
 
     }
@@ -50,4 +48,14 @@ public class MemberService {
         return new UpdatePwResponseDTO("비밀번호가 변경되었습니다.");
     }
 
+    // 프로필 캐릭터 변경
+    public UpdatePCharResponseDTO updatePChar(Long id, UpdatePCharRequestDTO updateRequest) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        member.setProfileCharacter(updateRequest.getProfileCharacter());
+        memberRepository.save(member);
+
+        return new UpdatePCharResponseDTO();
+    }
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/service/MemberService.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/member/service/MemberService.java
@@ -43,7 +43,6 @@ public class MemberService {
             return new UpdatePwResponseDTO("비밀번호가 일치하지 않습니다.");
         }
         member.setPassword(updateRequest.getNewPassword());
-        memberRepository.save(member);
 
         return new UpdatePwResponseDTO("비밀번호가 변경되었습니다.");
     }
@@ -54,7 +53,6 @@ public class MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         member.setProfileCharacter(updateRequest.getProfileCharacter());
-        memberRepository.save(member);
 
         return new UpdatePCharResponseDTO();
     }


### PR DESCRIPTION
feat: 프로필 캐릭터 수정

## 💻 작업 내용
- 프로필 캐릭터 수정 기능
- 내 정보 확인(info) 수정: 반환값에 프로필 캐릭터 추가
- DB: member테이블에 profile_character 컬럼을 추가했습니다.


# RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
