### PR TITLE
fIX: 전체 경험치 현황, 최근 달성 수정

### DIFF
--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/auth/service/AuthService.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/auth/service/AuthService.java
@@ -4,6 +4,8 @@ import blaybus.blaybus_backend.domain.auth.dto.LoginRequest;
 import blaybus.blaybus_backend.domain.auth.dto.LoginResponse;
 import blaybus.blaybus_backend.domain.auth.dto.SignupRequest;
 import blaybus.blaybus_backend.domain.auth.exception.AuthException;
+import blaybus.blaybus_backend.domain.experience.entity.ExperienceStatus;
+import blaybus.blaybus_backend.domain.experience.repository.ExperienceStatusRepository;
 import blaybus.blaybus_backend.domain.member.entity.Member;
 import blaybus.blaybus_backend.domain.member.exception.MemberException;
 import blaybus.blaybus_backend.domain.member.repository.MemberRepository;
@@ -22,6 +24,7 @@ import static blaybus.blaybus_backend.domain.auth.controller.SessionConst.MEMBER
 public class AuthService {
 
     private final MemberRepository memberRepository;
+    private final ExperienceStatusRepository experienceStatusRepository;
 
     public LoginResponse login(LoginRequest loginRequest, HttpServletRequest request) {
         Member member = memberRepository.findByLoginId(loginRequest.getLoginId())
@@ -44,6 +47,10 @@ public class AuthService {
 
         Member member = signupRequest.toMember();
         memberRepository.save(member);
+
+        ExperienceStatus expStatus = new ExperienceStatus();
+        expStatus.setMemberId(member.getId());
+        experienceStatusRepository.save(expStatus);
     }
 
     public void logout(Long memberId) {

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/entity/ExperienceStatus.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/entity/ExperienceStatus.java
@@ -3,8 +3,10 @@ package blaybus.blaybus_backend.domain.experience.entity;
 import blaybus.blaybus_backend.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
+@Setter
 @Getter
 public class ExperienceStatus {
 

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/repository/ExperienceStatusRepository.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/repository/ExperienceStatusRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ExperienceStatusRepository extends JpaRepository<ExperienceStatus, Long> {
-    Optional<ExperienceStatus> findByMember_Id(Long memberId);
+    Optional<ExperienceStatus> findByMemberId(Long memberId);
 
 }

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/repository/GainExperienceRepository.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/repository/GainExperienceRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public interface GainExperienceRepository extends JpaRepository<GainExperience, Long> {
     // 최근 달성한 경험치 반환
-    @Query("SELECT g FROM GainExperience g WHERE g.member.id = :memberId ORDER BY g.id DESC")
+    @Query("SELECT g FROM GainExperience g WHERE g.member.id = :memberId ORDER BY g.id DESC LIMIT 1")
     Optional<GainExperience> findRecentByMemberId(Long memberId);
 
     // Entire-ALL : 모두 반환

--- a/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/service/ExperienceService.java
+++ b/blaybus-backend/src/main/java/blaybus/blaybus_backend/domain/experience/service/ExperienceService.java
@@ -36,7 +36,7 @@ public class ExperienceService {
 
     // 경험치 현황 조회
     public ExpStatusResponseDTO getExpStatusById(Long id) {
-        ExperienceStatus expStatus = expStatusRepository.findByMember_Id(id)
+        ExperienceStatus expStatus = expStatusRepository.findByMemberId(id)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         int annualExp = expStatus.getFirstHalfPerformanceExp() + expStatus.getSecondHalfPerformanceExp()
                     + expStatus.getLeaderExp() + expStatus.getJobRoleExp();


### PR DESCRIPTION
## 📌 관련 이슈
close: #

## 💻 작업 내용
- 최근 달성 경험치 쿼리 수정 (뒷부분이 사라졌었네요...)
- findeByMember_Id함수명 변경
- 경험치 현황에 데이터가 없는 것을 방지하기 위해 회원가입 시 Experience_status 데이터 자동 삽입 처리

# RCA 룰
- R: 꼭 반영해 주세요. 적극적으로 고려해 주세요. (Request changes)
- C: 웬만하면 반영해 주세요. (Comment)
- A: 반영해도 좋고 넘어가도 좋습니다. 그냥 사소한 의견입니다. (Approve)
